### PR TITLE
Fix incrementing with tags

### DIFF
--- a/src/StatsRecorder.js
+++ b/src/StatsRecorder.js
@@ -8,11 +8,21 @@ export default function StatsRecorder({publisher, globalTags = []}) {
   };
 
   this.increment = (metric, value, tags) => {
-    add(buildStat('increment', metric, value || 1, tags));
+    if (!Number.isInteger(value)) {
+      tags = value;
+      value = 1;
+    }
+
+    add(buildStat('increment', metric, value, tags));
   };
 
   this.decrement = (metric, value, tags) => {
-    add(buildStat('decrement', metric, value || 1, tags));
+    if (!Number.isInteger(value)) {
+      tags = value;
+      value = 1;
+    }
+
+    add(buildStat('decrement', metric, value, tags));
   };
 
   this.gauge = (metric, value, tags) => {

--- a/test/StatsRecorderTest.js
+++ b/test/StatsRecorderTest.js
@@ -97,6 +97,15 @@ describe('StatsRecorder', () => {
 
       expectStat({stat: name, params: [metricName, defaultValue, []]});
     });
+
+    it(`records '${name}' metric with value of one and tags if value is not present`, () => {
+      const statsRecorder = new StatsRecorder(defaultOpts);
+      const metricName = 'metric-name';
+      const metricTags = ['foo:bar'];
+      statsRecorder[name](metricName, metricTags);
+
+      expectStat({stat: name, params: [metricName, 1, metricTags]});
+    });
   }
 
   function expectStat(expectedStat) {


### PR DESCRIPTION
CHAN-300

Previously, when value was not present in arguments when calling
the increment function, the additional tags were sent separately
from the actual tags array, resulting in custom tags not showing
up in Datadog.

Fix this by setting value to increment by with 1 and tags with the
value parameter when value isn't an integer (is an array of tags).