### PR TITLE
Fix pruning objects inside arrays

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client-logger",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "",
   "module": "dist/client-logger.esm.js",
   "browser": "dist/client-logger.umd.js",

--- a/src/Logger.js
+++ b/src/Logger.js
@@ -50,7 +50,14 @@ export default function Logger({
 
     for (let i = 0; i < arr.length; i++) {
       if (i === maxArrayLength) {
-        formattedArray.push('-pruned-');
+        const prevValue = arr[i - 1];
+        if (prevValue && typeof prevValue === 'object' && !Array.isArray(prevValue)) {
+          // Our log consumer does not accept strings mixed with objects in arrays,
+          // i.e. cannot simply use '-pruned-' here.
+          formattedArray.push({pruned: true});
+        } else {
+          formattedArray.push('-pruned-');
+        }
         break;
       }
 

--- a/src/Logger.js
+++ b/src/Logger.js
@@ -51,9 +51,12 @@ export default function Logger({
     for (let i = 0; i < arr.length; i++) {
       if (i === maxArrayLength) {
         const prevValue = arr[i - 1];
-        if (prevValue && typeof prevValue === 'object' && !Array.isArray(prevValue)) {
-          // Our log consumer does not accept strings mixed with objects in arrays,
-          // i.e. cannot simply use '-pruned-' here.
+
+        // Our log consumer does not mixed objects in arrays,
+        // i.e. cannot simply use '-pruned-' here.
+        if (Array.isArray(prevValue)) {
+          formattedArray.push(['-pruned-']);
+        } else if (prevValue && typeof prevValue === 'object') {
           formattedArray.push({pruned: true});
         } else {
           formattedArray.push('-pruned-');

--- a/test/LoggerTest.js
+++ b/test/LoggerTest.js
@@ -9,7 +9,8 @@ describe('Logger', () => {
   let windowConsole;
   let localStorage;
   const currentIsoDate = () => 'current-iso-date';
-  const loggerOpts = memo().is(() => ({}));
+  const maxArrayLength = 3;
+  const loggerOpts = memo().is(() => ({maxArrayLength}));
 
   beforeEach(() => {
     windowConsole = {info: sinon.stub()};
@@ -61,12 +62,22 @@ describe('Logger', () => {
 
       it('prunes long arrays in an object', () => {
         const message = 'a message';
-        const obj = {arr: Array.from(Array(50).keys())};
+        const zeroTo50 = Array.from(Array(50).keys());
+        const obj = {
+          simple_array: zeroTo50,
+          array_with_objects: zeroTo50.map(key => ({key}))
+        };
 
         logger[level](message, obj);
         expectLog({
           level,
-          attributes: [message, {arr: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, '-pruned-']}]
+          attributes: [
+            message,
+            {
+              simple_array: [0, 1, 2, '-pruned-'],
+              array_with_objects: [{key: 0}, {key: 1}, {key: 2}, {pruned: true}]
+            }
+          ]
         });
       });
 

--- a/test/LoggerTest.js
+++ b/test/LoggerTest.js
@@ -65,7 +65,8 @@ describe('Logger', () => {
         const zeroTo50 = Array.from(Array(50).keys());
         const obj = {
           simple_array: zeroTo50,
-          array_with_objects: zeroTo50.map(key => ({key}))
+          array_with_objects: zeroTo50.map(key => ({key})),
+          array_with_arrays: zeroTo50.map(key => [key])
         };
 
         logger[level](message, obj);
@@ -75,7 +76,8 @@ describe('Logger', () => {
             message,
             {
               simple_array: [0, 1, 2, '-pruned-'],
-              array_with_objects: [{key: 0}, {key: 1}, {key: 2}, {pruned: true}]
+              array_with_objects: [{key: 0}, {key: 1}, {key: 2}, {pruned: true}],
+              array_with_arrays: [[0], [1], [2], ['-pruned-']]
             }
           ]
         });


### PR DESCRIPTION
ElasticSearch does not accept arrays in which objects and strings are
mixed, which can often be the case when arrays are pruned. Change
pruning so that the last element is replaced with `{pruned: true}`
instead of the '-pruned-' token to work around this.

INF-2622