### PR TITLE
Prune arrays that exceed depth limit

### DIFF
--- a/src/Logger.js
+++ b/src/Logger.js
@@ -46,6 +46,8 @@ export default function Logger({
     windowConsole && (liveLogsEnabled || localStorage[liveLogsKey] === '1');
 
   const formatArray = (arr, depthLevel) => {
+    if (maxObjectDepth === depthLevel) return ['-pruned-'];
+
     const formattedArray = [];
 
     for (let i = 0; i < arr.length; i++) {

--- a/test/LoggerTest.js
+++ b/test/LoggerTest.js
@@ -83,6 +83,21 @@ describe('Logger', () => {
         });
       });
 
+      it('prunes nested arrays that exceed depth limit', () => {
+        const message = 'a message';
+
+        let recursive_object = {};
+        recursive_object.f = recursive_object;
+
+        logger[level](message, {
+          a: {b: {c: [[{d: recursive_object}], {f: 'string'}]}}
+        });
+        expectLog({
+          level,
+          attributes: [message, {a: {b: {c: ['-pruned-']}}}]
+        });
+      });
+
       it('extracts error information from error object', () => {
         const error = new Error('oh snap');
 


### PR DESCRIPTION
Previously we got `Maximum call stack exceeded` error when trying
to reach an error that was nested too deeply in an array.

Now we prune arrays that nest too deep.

https://sentry.io/organizations/glia/issues/2829151376/
CHAN-1862