### PR TITLE
Null instead of empty object

### DIFF
--- a/dist/client-logger.esm.js
+++ b/dist/client-logger.esm.js
@@ -62,17 +62,11 @@ function HttpTransport(_ref) {
 function _typeof(obj) {
   "@babel/helpers - typeof";
 
-  if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") {
-    _typeof = function (obj) {
-      return typeof obj;
-    };
-  } else {
-    _typeof = function (obj) {
-      return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj;
-    };
-  }
-
-  return _typeof(obj);
+  return _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (obj) {
+    return typeof obj;
+  } : function (obj) {
+    return obj && "function" == typeof Symbol && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj;
+  }, _typeof(obj);
 }
 
 function Breadcrumbs() {
@@ -158,6 +152,7 @@ function Logger(_ref) {
   };
 
   var formatArray = function formatArray(arr, depthLevel) {
+    if (maxObjectDepth === depthLevel) return ['-pruned-'];
     var formattedArray = [];
 
     for (var i = 0; i < arr.length; i++) {
@@ -202,7 +197,7 @@ function Logger(_ref) {
 
   var format = function format(obj) {
     var depthLevel = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : 0;
-    if (primitives.indexOf(_typeof(obj)) !== -1) return obj;else if (typeof obj === 'function') return '<Function>';else if (obj instanceof Error) return formatError(obj);else if (Array.isArray(obj)) return formatArray(obj, depthLevel);else return formatObject(obj, depthLevel);
+    if (primitives.indexOf(_typeof(obj)) !== -1) return obj;else if (typeof obj === 'function') return '<Function>';else if (obj === null) return null;else if (obj instanceof Error) return formatError(obj);else if (Array.isArray(obj)) return formatArray(obj, depthLevel);else return formatObject(obj, depthLevel);
   };
 
   var log = function log(level) {

--- a/dist/client-logger.umd.js
+++ b/dist/client-logger.umd.js
@@ -1,8 +1,8 @@
 (function (global, factory) {
   typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
   typeof define === 'function' && define.amd ? define(['exports'], factory) :
-  (global = typeof globalThis !== 'undefined' ? globalThis : global || self, factory(global['client-logger'] = {}));
-}(this, (function (exports) { 'use strict';
+  (global = typeof globalThis !== 'undefined' ? globalThis : global || self, factory(global["client-logger"] = {}));
+})(this, (function (exports) { 'use strict';
 
   function CustomTransport(processFn) {
     if (!processFn) throw new Error('processFn must be specificed when using CustomTransport');
@@ -68,17 +68,11 @@
   function _typeof(obj) {
     "@babel/helpers - typeof";
 
-    if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") {
-      _typeof = function (obj) {
-        return typeof obj;
-      };
-    } else {
-      _typeof = function (obj) {
-        return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj;
-      };
-    }
-
-    return _typeof(obj);
+    return _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (obj) {
+      return typeof obj;
+    } : function (obj) {
+      return obj && "function" == typeof Symbol && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj;
+    }, _typeof(obj);
   }
 
   function Breadcrumbs() {
@@ -164,6 +158,7 @@
     };
 
     var formatArray = function formatArray(arr, depthLevel) {
+      if (maxObjectDepth === depthLevel) return ['-pruned-'];
       var formattedArray = [];
 
       for (var i = 0; i < arr.length; i++) {
@@ -208,7 +203,7 @@
 
     var format = function format(obj) {
       var depthLevel = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : 0;
-      if (primitives.indexOf(_typeof(obj)) !== -1) return obj;else if (typeof obj === 'function') return '<Function>';else if (obj instanceof Error) return formatError(obj);else if (Array.isArray(obj)) return formatArray(obj, depthLevel);else return formatObject(obj, depthLevel);
+      if (primitives.indexOf(_typeof(obj)) !== -1) return obj;else if (typeof obj === 'function') return '<Function>';else if (obj === null) return null;else if (obj instanceof Error) return formatError(obj);else if (Array.isArray(obj)) return formatArray(obj, depthLevel);else return formatObject(obj, depthLevel);
     };
 
     var log = function log(level) {
@@ -483,4 +478,4 @@
 
   Object.defineProperty(exports, '__esModule', { value: true });
 
-})));
+}));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client-logger",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "",
   "module": "dist/client-logger.esm.js",
   "browser": "dist/client-logger.umd.js",

--- a/src/Logger.js
+++ b/src/Logger.js
@@ -90,6 +90,7 @@ export default function Logger({
   const format = (obj, depthLevel = 0) => {
     if (primitives.indexOf(typeof obj) !== -1) return obj;
     else if (typeof obj === 'function') return '<Function>';
+    else if (obj === null) return null;
     else if (obj instanceof Error) return formatError(obj);
     else if (Array.isArray(obj)) return formatArray(obj, depthLevel);
     else return formatObject(obj, depthLevel);

--- a/test/LoggerTest.js
+++ b/test/LoggerTest.js
@@ -48,6 +48,11 @@ describe('Logger', () => {
         expectLog({level, attributes: ['<Function>']});
       });
 
+      it('keeps null unchanged', () => {
+        logger[level]({a: null});
+        expectLog({level, attributes: [{a: null}]});
+      });
+
       it('prunes deeply nested objects', () => {
         const message = 'a message';
 


### PR DESCRIPTION
Sending empty object as a default value to backend is confusing and
causes issues for indexer. A clear case that should not be casted to
`{}` is null (think of integer and char values).