### PR TITLE
Allow using whitelist for Logger

### DIFF
--- a/dist/client-logger.esm.js
+++ b/dist/client-logger.esm.js
@@ -5,16 +5,17 @@ function CustomTransport(processFn) {
 
 function HttpTransport(_ref) {
   var url = _ref.url,
-      method = _ref.method,
-      headers = _ref.headers,
-      encode = _ref.encode;
+    method = _ref.method,
+    headers = _ref.headers,
+    encode = _ref.encode;
   if (!url) throw new Error('url must be specificed when using HttpTransport');
   if (!method) method = 'POST';
   if (!headers) headers = {};
   if (!encode) encode = function encode(payload) {
     return JSON.stringify(payload);
-  }; // XMLHttpRequest is only used when Fetch API is not supported
+  };
 
+  // XMLHttpRequest is only used when Fetch API is not supported
   var sendUsingXMLHttpRequest = function sendUsingXMLHttpRequest(_ref2) {
     var payload = _ref2.payload;
     return new Promise(function (resolve, reject) {
@@ -23,7 +24,6 @@ function HttpTransport(_ref) {
       Object.keys(headers).forEach(function (key) {
         xhr.setRequestHeader(key, headers[key]);
       });
-
       xhr.onload = function () {
         if (xhr.status < 200 || status >= 300) {
           reject();
@@ -31,21 +31,18 @@ function HttpTransport(_ref) {
           resolve();
         }
       };
-
       xhr.onerror = function () {
         return reject();
       };
-
       xhr.send(encode(payload));
     });
   };
+
   /**
    * We prefer Fetch API beacuse it has `keepalive` flag. The keepalive option
    * can be used to allow the request to outlive the page. Fetch with the
    * keepalive flag is a replacement for the sendBeacon API.
    */
-
-
   var sendUsingFetchAPI = function sendUsingFetchAPI(_ref3) {
     var payload = _ref3.payload;
     return window.fetch(url, {
@@ -55,111 +52,99 @@ function HttpTransport(_ref) {
       body: encode(payload)
     });
   };
-
   this.process = window.fetch ? sendUsingFetchAPI : sendUsingXMLHttpRequest;
 }
 
-function _typeof(obj) {
+function _typeof(o) {
   "@babel/helpers - typeof";
 
-  return _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (obj) {
-    return typeof obj;
-  } : function (obj) {
-    return obj && "function" == typeof Symbol && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj;
-  }, _typeof(obj);
+  return _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (o) {
+    return typeof o;
+  } : function (o) {
+    return o && "function" == typeof Symbol && o.constructor === Symbol && o !== Symbol.prototype ? "symbol" : typeof o;
+  }, _typeof(o);
 }
 
 function Breadcrumbs() {
   var _this = this;
-
   this.list = [];
-
   this.add = function (crumb) {
     if (_this.list.length === 10) {
       _this.list = _this.list.slice(1);
     }
-
     _this.list.push(crumb);
   };
 }
 
 var merge = function merge(obj1, obj2) {
   var obj3 = {};
-
-  for (var attrname in obj1) {
-    obj3[attrname] = obj1[attrname];
-  }
-
-  for (var _attrname in obj2) {
-    obj3[_attrname] = obj2[_attrname];
-  }
-
+  for (var attrname in obj1) obj3[attrname] = obj1[attrname];
+  for (var _attrname in obj2) obj3[_attrname] = obj2[_attrname];
   return obj3;
 };
-
 var evaluateTags = function evaluateTags(tags) {
   var result = {};
-
   for (var key in tags) {
     var value = tags[key];
-
     if (typeof value == 'function') {
       result[key] = value();
     } else {
       result[key] = value;
     }
   }
-
   return result;
 };
-
 var forEachEnumerableOwnProperty = function forEachEnumerableOwnProperty(obj, callback) {
   for (var k in obj) {
     if (Object.prototype.hasOwnProperty.call(obj, k)) callback(k);
   }
 };
-
 var primitives = ['string', 'number', 'boolean', 'null', 'undefined'];
 function Logger(_ref) {
   var _arguments = arguments;
   var publisher = _ref.publisher,
-      _ref$tags = _ref.tags,
-      tags = _ref$tags === void 0 ? {} : _ref$tags,
-      _ref$currentIsoDate = _ref.currentIsoDate,
-      currentIsoDate = _ref$currentIsoDate === void 0 ? function () {
-    return new Date().toISOString();
-  } : _ref$currentIsoDate,
-      _ref$maxObjectDepth = _ref.maxObjectDepth,
-      maxObjectDepth = _ref$maxObjectDepth === void 0 ? 3 : _ref$maxObjectDepth,
-      _ref$maxArrayLength = _ref.maxArrayLength,
-      maxArrayLength = _ref$maxArrayLength === void 0 ? 10 : _ref$maxArrayLength,
-      _ref$windowConsole = _ref.windowConsole,
-      windowConsole = _ref$windowConsole === void 0 ? window.console : _ref$windowConsole,
-      _ref$localStorage = _ref.localStorage,
-      localStorage = _ref$localStorage === void 0 ? window.localStorage : _ref$localStorage,
-      _ref$liveLogsKey = _ref.liveLogsKey,
-      liveLogsKey = _ref$liveLogsKey === void 0 ? 'sm.live_logs' : _ref$liveLogsKey,
-      _ref$liveLogsEnabled = _ref.liveLogsEnabled,
-      liveLogsEnabled = _ref$liveLogsEnabled === void 0 ? false : _ref$liveLogsEnabled;
+    _ref$tags = _ref.tags,
+    tags = _ref$tags === void 0 ? {} : _ref$tags,
+    _ref$currentIsoDate = _ref.currentIsoDate,
+    currentIsoDate = _ref$currentIsoDate === void 0 ? function () {
+      return new Date().toISOString();
+    } : _ref$currentIsoDate,
+    _ref$maxObjectDepth = _ref.maxObjectDepth,
+    maxObjectDepth = _ref$maxObjectDepth === void 0 ? 3 : _ref$maxObjectDepth,
+    _ref$maxArrayLength = _ref.maxArrayLength,
+    maxArrayLength = _ref$maxArrayLength === void 0 ? 10 : _ref$maxArrayLength,
+    _ref$windowConsole = _ref.windowConsole,
+    windowConsole = _ref$windowConsole === void 0 ? window.console : _ref$windowConsole,
+    _ref$localStorage = _ref.localStorage,
+    localStorage = _ref$localStorage === void 0 ? window.localStorage : _ref$localStorage,
+    _ref$liveLogsKey = _ref.liveLogsKey,
+    liveLogsKey = _ref$liveLogsKey === void 0 ? 'sm.live_logs' : _ref$liveLogsKey,
+    _ref$liveLogsEnabled = _ref.liveLogsEnabled,
+    liveLogsEnabled = _ref$liveLogsEnabled === void 0 ? false : _ref$liveLogsEnabled,
+    _ref$whitelist = _ref.whitelist,
+    whitelist = _ref$whitelist === void 0 ? [] : _ref$whitelist;
+  // Keeping whitelist as array looks better. We can still get the performance of
+  // hash by transforming the array into an object at Logger initialisation.
+  var optimizedWhitelist = {};
+  for (var i = 0; i < whitelist.length; i++) {
+    optimizedWhitelist[whitelist[i]] = true;
+  }
   var breadcrumbs = new Breadcrumbs();
-
   var add = function add(item) {
     return publisher.addToBucket('logs', item);
   };
-
   var isLiveLoggingEnabled = function isLiveLoggingEnabled() {
     return windowConsole && (liveLogsEnabled || localStorage[liveLogsKey] === '1');
   };
-
   var formatArray = function formatArray(arr, depthLevel) {
     if (maxObjectDepth === depthLevel) return ['-pruned-'];
     var formattedArray = [];
+    for (var _i = 0; _i < arr.length; _i++) {
+      if (_i === maxArrayLength) {
+        var prevValue = arr[_i - 1];
 
-    for (var i = 0; i < arr.length; i++) {
-      if (i === maxArrayLength) {
-        var prevValue = arr[i - 1]; // Our log consumer does not mixed objects in arrays,
+        // Our log consumer does not mixed objects in arrays,
         // i.e. cannot simply use '-pruned-' here.
-
         if (Array.isArray(prevValue)) {
           formattedArray.push(['-pruned-']);
         } else if (prevValue && _typeof(prevValue) === 'object') {
@@ -169,44 +154,51 @@ function Logger(_ref) {
         } else {
           formattedArray.push('-pruned-');
         }
-
         break;
       }
-
-      formattedArray.push(format(arr[i], depthLevel + 1));
+      formattedArray.push(format(arr[_i], depthLevel + 1));
     }
-
     return formattedArray;
   };
-
   var formatObject = function formatObject(obj, depthLevel) {
     if (maxObjectDepth === depthLevel) return '-pruned-';
     var formatted = {};
     forEachEnumerableOwnProperty(obj, function (key) {
-      formatted[key] = format(obj[key], depthLevel + 1);
+      var value = obj[key];
+      if (whitelist.length === 0 || optimizedWhitelist[key]) {
+        formatted[key] = format(value, depthLevel + 1);
+      } else {
+        // Our log consumer does not mixed objects in arrays,
+        // i.e. cannot simply use '-redacted-' here.
+        if (Array.isArray(value)) {
+          formatted[key] = ['-redacted-'];
+        } else if (value && _typeof(value) === 'object') {
+          formatted[key] = {
+            redacted: true
+          };
+        } else {
+          formatted[key] = '-redacted-';
+        }
+      }
     });
     return formatted;
   };
-
   var formatError = function formatError(error) {
     return {
       message: error.message,
       stack: error.stack
     };
   };
-
   var format = function format(obj) {
     var depthLevel = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : 0;
     if (primitives.indexOf(_typeof(obj)) !== -1) return obj;else if (typeof obj === 'function') return '<Function>';else if (obj === null) return null;else if (obj instanceof Error) return formatError(obj);else if (Array.isArray(obj)) return formatArray(obj, depthLevel);else return formatObject(obj, depthLevel);
   };
-
   var log = function log(level) {
     return function () {
       if (isLiveLoggingEnabled()) {
         var writer = windowConsole[level] || windowConsole['log'];
         writer.apply(writer, arguments);
       }
-
       var attributes = Array.prototype.slice.call(arguments).map(function (arg) {
         return format(arg, 0);
       }).filter(function (attribute) {
@@ -218,7 +210,6 @@ function Logger(_ref) {
         attributes: attributes,
         timestamp: currentIsoDate()
       });
-
       if (level === 'error') {
         params = merge(params, {
           breadcrumbs: breadcrumbs.list
@@ -226,40 +217,32 @@ function Logger(_ref) {
       } else {
         breadcrumbs.add(params);
       }
-
       add(params);
     };
   };
-
   var findTopLevelError = function findTopLevelError(args) {
     return args.filter(function (arg) {
       return arg instanceof Error;
     })[0];
   };
-
   this.debug = log('debug');
   this.log = log('info');
   this.info = log('info');
   this.warn = log('warn');
-
   this.error = function () {
     var args = Array.prototype.slice.call(arguments);
     var maybeError = findTopLevelError(args);
-
     if (maybeError && maybeError._acked) {
       return;
     }
-
     if (typeof args[0] === 'string' && !maybeError) args[0] = new Error(args[0]);
     return log('error').apply(null, args);
   };
-
   this.withTags = function (newTags) {
     return new Logger(merge(_arguments[0], {
       tags: merge(tags, newTags)
     }));
   };
-
   this.enableLiveLogs = function () {
     return localStorage[liveLogsKey] = '1';
   };
@@ -270,37 +253,32 @@ var objectValues = function objectValues(obj) {
     return obj[k];
   });
 };
-
 function Publisher() {
   var _ref = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {},
-      _ref$publishInterval = _ref.publishInterval,
-      publishInterval = _ref$publishInterval === void 0 ? 3000 : _ref$publishInterval,
-      _ref$maximumBatchSize = _ref.maximumBatchSize,
-      maximumBatchSize = _ref$maximumBatchSize === void 0 ? 50 : _ref$maximumBatchSize,
-      _ref$maximumBufferSiz = _ref.maximumBufferSize,
-      maximumBufferSize = _ref$maximumBufferSiz === void 0 ? 1000 : _ref$maximumBufferSiz,
-      _ref$maximumConsecuti = _ref.maximumConsecutiveRetries,
-      maximumConsecutiveRetries = _ref$maximumConsecuti === void 0 ? 10 : _ref$maximumConsecuti,
-      _ref$transports = _ref.transports,
-      transports = _ref$transports === void 0 ? [] : _ref$transports;
-
+    _ref$publishInterval = _ref.publishInterval,
+    publishInterval = _ref$publishInterval === void 0 ? 3000 : _ref$publishInterval,
+    _ref$maximumBatchSize = _ref.maximumBatchSize,
+    maximumBatchSize = _ref$maximumBatchSize === void 0 ? 50 : _ref$maximumBatchSize,
+    _ref$maximumBufferSiz = _ref.maximumBufferSize,
+    maximumBufferSize = _ref$maximumBufferSiz === void 0 ? 1000 : _ref$maximumBufferSiz,
+    _ref$maximumConsecuti = _ref.maximumConsecutiveRetries,
+    maximumConsecutiveRetries = _ref$maximumConsecuti === void 0 ? 10 : _ref$maximumConsecuti,
+    _ref$transports = _ref.transports,
+    transports = _ref$transports === void 0 ? [] : _ref$transports;
   var addTransport = function addTransport(transport) {
     var _ref2 = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {},
-        position = _ref2.position;
-
+      position = _ref2.position;
     // In normal languages we could just do `position || transports.length`. In
     // javascript however 0 is treated as false which sets the position to
     // transports.length.
     if (position === undefined) position = transports.length;
     transports.splice(position, 0, transport);
   };
-
   var buckets = {};
   var retries = {};
-
   var send = function send(_ref3) {
     var transports = _ref3.transports,
-        payload = _ref3.payload;
+      payload = _ref3.payload;
     if (transports.length === 0) return Promise.reject();
     return transports[0].process({
       payload: payload
@@ -311,19 +289,16 @@ function Publisher() {
       });
     });
   };
-
   var isEmptyPayload = function isEmptyPayload(payload) {
     return Object.keys(payload).length === 0 || objectValues(payload).every(function (items) {
       return items.length === 0;
     });
   };
-
   var flush = function flush() {
     var payload = {};
     Object.keys(buckets).forEach(function (key) {
       payload[key] = buckets[key].splice(0, maximumBatchSize);
     });
-
     if (!isEmptyPayload(payload)) {
       return send({
         transports: transports,
@@ -337,7 +312,6 @@ function Publisher() {
       })["catch"](function () {
         Object.keys(payload).forEach(function (key) {
           retries[key]++;
-
           if (retries[key] < maximumConsecutiveRetries) {
             buckets[key] = payload[key].concat(buckets[key]);
           } else {
@@ -351,11 +325,9 @@ function Publisher() {
       return Promise.resolve();
     }
   };
-
   var started = false;
   var timer = null;
   var flushInProgress = false;
-
   var start = function start() {
     if (started) throw new Error('Publisher is already started');
     started = true;
@@ -371,25 +343,20 @@ function Publisher() {
     }, publishInterval);
     window.addEventListener('unload', flush);
   };
-
   var stop = function stop() {
     started = false;
     clearInterval(timer);
   };
-
   var addToBucket = function addToBucket(bucketKey, item) {
     if (!buckets[bucketKey]) {
       if (!retries[bucketKey]) {
         retries[bucketKey] = 0;
       }
-
       buckets[bucketKey] = [];
     }
-
     buckets[bucketKey].push(item);
     buckets[bucketKey].splice(maximumBufferSize);
   };
-
   return {
     start: start,
     stop: stop,
@@ -403,13 +370,11 @@ function Publisher() {
 
 function StatsRecorder(_ref) {
   var publisher = _ref.publisher,
-      _ref$globalTags = _ref.globalTags,
-      globalTags = _ref$globalTags === void 0 ? [] : _ref$globalTags;
-
+    _ref$globalTags = _ref.globalTags,
+    globalTags = _ref$globalTags === void 0 ? [] : _ref$globalTags;
   var add = function add(item) {
     return publisher.addToBucket('stats', item);
   };
-
   var buildStat = function buildStat(stat, metric, value, tags) {
     if (!tags) tags = [];
     return {
@@ -417,41 +382,32 @@ function StatsRecorder(_ref) {
       params: [metric, value, globalTags.concat(tags)]
     };
   };
-
   this.increment = function (metric, value, tags) {
     if (isNaN(parseInt(value))) {
       tags = value;
       value = 1;
     }
-
     add(buildStat('increment', metric, value, tags));
   };
-
   this.decrement = function (metric, value, tags) {
     if (isNaN(parseInt(value))) {
       tags = value;
       value = 1;
     }
-
     add(buildStat('decrement', metric, value, tags));
   };
-
   this.gauge = function (metric, value, tags) {
     add(buildStat('gauge', metric, value, tags));
   };
-
   this.histogram = function (metric, value, tags) {
     add(buildStat('histogram', metric, value, tags));
   };
-
   this.timing = function (metric, value, tags) {
     add(buildStat('timing', metric, value, tags));
   };
-
   this.set = function (metric, value, tags) {
     add(buildStat('set', metric, value, tags));
   };
-
   this.withTags = function (tags) {
     return new StatsRecorder({
       publisher: publisher,

--- a/dist/client-logger.umd.js
+++ b/dist/client-logger.umd.js
@@ -11,16 +11,17 @@
 
   function HttpTransport(_ref) {
     var url = _ref.url,
-        method = _ref.method,
-        headers = _ref.headers,
-        encode = _ref.encode;
+      method = _ref.method,
+      headers = _ref.headers,
+      encode = _ref.encode;
     if (!url) throw new Error('url must be specificed when using HttpTransport');
     if (!method) method = 'POST';
     if (!headers) headers = {};
     if (!encode) encode = function encode(payload) {
       return JSON.stringify(payload);
-    }; // XMLHttpRequest is only used when Fetch API is not supported
+    };
 
+    // XMLHttpRequest is only used when Fetch API is not supported
     var sendUsingXMLHttpRequest = function sendUsingXMLHttpRequest(_ref2) {
       var payload = _ref2.payload;
       return new Promise(function (resolve, reject) {
@@ -29,7 +30,6 @@
         Object.keys(headers).forEach(function (key) {
           xhr.setRequestHeader(key, headers[key]);
         });
-
         xhr.onload = function () {
           if (xhr.status < 200 || status >= 300) {
             reject();
@@ -37,21 +37,18 @@
             resolve();
           }
         };
-
         xhr.onerror = function () {
           return reject();
         };
-
         xhr.send(encode(payload));
       });
     };
+
     /**
      * We prefer Fetch API beacuse it has `keepalive` flag. The keepalive option
      * can be used to allow the request to outlive the page. Fetch with the
      * keepalive flag is a replacement for the sendBeacon API.
      */
-
-
     var sendUsingFetchAPI = function sendUsingFetchAPI(_ref3) {
       var payload = _ref3.payload;
       return window.fetch(url, {
@@ -61,111 +58,99 @@
         body: encode(payload)
       });
     };
-
     this.process = window.fetch ? sendUsingFetchAPI : sendUsingXMLHttpRequest;
   }
 
-  function _typeof(obj) {
+  function _typeof(o) {
     "@babel/helpers - typeof";
 
-    return _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (obj) {
-      return typeof obj;
-    } : function (obj) {
-      return obj && "function" == typeof Symbol && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj;
-    }, _typeof(obj);
+    return _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (o) {
+      return typeof o;
+    } : function (o) {
+      return o && "function" == typeof Symbol && o.constructor === Symbol && o !== Symbol.prototype ? "symbol" : typeof o;
+    }, _typeof(o);
   }
 
   function Breadcrumbs() {
     var _this = this;
-
     this.list = [];
-
     this.add = function (crumb) {
       if (_this.list.length === 10) {
         _this.list = _this.list.slice(1);
       }
-
       _this.list.push(crumb);
     };
   }
 
   var merge = function merge(obj1, obj2) {
     var obj3 = {};
-
-    for (var attrname in obj1) {
-      obj3[attrname] = obj1[attrname];
-    }
-
-    for (var _attrname in obj2) {
-      obj3[_attrname] = obj2[_attrname];
-    }
-
+    for (var attrname in obj1) obj3[attrname] = obj1[attrname];
+    for (var _attrname in obj2) obj3[_attrname] = obj2[_attrname];
     return obj3;
   };
-
   var evaluateTags = function evaluateTags(tags) {
     var result = {};
-
     for (var key in tags) {
       var value = tags[key];
-
       if (typeof value == 'function') {
         result[key] = value();
       } else {
         result[key] = value;
       }
     }
-
     return result;
   };
-
   var forEachEnumerableOwnProperty = function forEachEnumerableOwnProperty(obj, callback) {
     for (var k in obj) {
       if (Object.prototype.hasOwnProperty.call(obj, k)) callback(k);
     }
   };
-
   var primitives = ['string', 'number', 'boolean', 'null', 'undefined'];
   function Logger(_ref) {
     var _arguments = arguments;
     var publisher = _ref.publisher,
-        _ref$tags = _ref.tags,
-        tags = _ref$tags === void 0 ? {} : _ref$tags,
-        _ref$currentIsoDate = _ref.currentIsoDate,
-        currentIsoDate = _ref$currentIsoDate === void 0 ? function () {
-      return new Date().toISOString();
-    } : _ref$currentIsoDate,
-        _ref$maxObjectDepth = _ref.maxObjectDepth,
-        maxObjectDepth = _ref$maxObjectDepth === void 0 ? 3 : _ref$maxObjectDepth,
-        _ref$maxArrayLength = _ref.maxArrayLength,
-        maxArrayLength = _ref$maxArrayLength === void 0 ? 10 : _ref$maxArrayLength,
-        _ref$windowConsole = _ref.windowConsole,
-        windowConsole = _ref$windowConsole === void 0 ? window.console : _ref$windowConsole,
-        _ref$localStorage = _ref.localStorage,
-        localStorage = _ref$localStorage === void 0 ? window.localStorage : _ref$localStorage,
-        _ref$liveLogsKey = _ref.liveLogsKey,
-        liveLogsKey = _ref$liveLogsKey === void 0 ? 'sm.live_logs' : _ref$liveLogsKey,
-        _ref$liveLogsEnabled = _ref.liveLogsEnabled,
-        liveLogsEnabled = _ref$liveLogsEnabled === void 0 ? false : _ref$liveLogsEnabled;
+      _ref$tags = _ref.tags,
+      tags = _ref$tags === void 0 ? {} : _ref$tags,
+      _ref$currentIsoDate = _ref.currentIsoDate,
+      currentIsoDate = _ref$currentIsoDate === void 0 ? function () {
+        return new Date().toISOString();
+      } : _ref$currentIsoDate,
+      _ref$maxObjectDepth = _ref.maxObjectDepth,
+      maxObjectDepth = _ref$maxObjectDepth === void 0 ? 3 : _ref$maxObjectDepth,
+      _ref$maxArrayLength = _ref.maxArrayLength,
+      maxArrayLength = _ref$maxArrayLength === void 0 ? 10 : _ref$maxArrayLength,
+      _ref$windowConsole = _ref.windowConsole,
+      windowConsole = _ref$windowConsole === void 0 ? window.console : _ref$windowConsole,
+      _ref$localStorage = _ref.localStorage,
+      localStorage = _ref$localStorage === void 0 ? window.localStorage : _ref$localStorage,
+      _ref$liveLogsKey = _ref.liveLogsKey,
+      liveLogsKey = _ref$liveLogsKey === void 0 ? 'sm.live_logs' : _ref$liveLogsKey,
+      _ref$liveLogsEnabled = _ref.liveLogsEnabled,
+      liveLogsEnabled = _ref$liveLogsEnabled === void 0 ? false : _ref$liveLogsEnabled,
+      _ref$whitelist = _ref.whitelist,
+      whitelist = _ref$whitelist === void 0 ? [] : _ref$whitelist;
+    // Keeping whitelist as array looks better. We can still get the performance of
+    // hash by transforming the array into an object at Logger initialisation.
+    var optimizedWhitelist = {};
+    for (var i = 0; i < whitelist.length; i++) {
+      optimizedWhitelist[whitelist[i]] = true;
+    }
     var breadcrumbs = new Breadcrumbs();
-
     var add = function add(item) {
       return publisher.addToBucket('logs', item);
     };
-
     var isLiveLoggingEnabled = function isLiveLoggingEnabled() {
       return windowConsole && (liveLogsEnabled || localStorage[liveLogsKey] === '1');
     };
-
     var formatArray = function formatArray(arr, depthLevel) {
       if (maxObjectDepth === depthLevel) return ['-pruned-'];
       var formattedArray = [];
+      for (var _i = 0; _i < arr.length; _i++) {
+        if (_i === maxArrayLength) {
+          var prevValue = arr[_i - 1];
 
-      for (var i = 0; i < arr.length; i++) {
-        if (i === maxArrayLength) {
-          var prevValue = arr[i - 1]; // Our log consumer does not mixed objects in arrays,
+          // Our log consumer does not mixed objects in arrays,
           // i.e. cannot simply use '-pruned-' here.
-
           if (Array.isArray(prevValue)) {
             formattedArray.push(['-pruned-']);
           } else if (prevValue && _typeof(prevValue) === 'object') {
@@ -175,44 +160,51 @@
           } else {
             formattedArray.push('-pruned-');
           }
-
           break;
         }
-
-        formattedArray.push(format(arr[i], depthLevel + 1));
+        formattedArray.push(format(arr[_i], depthLevel + 1));
       }
-
       return formattedArray;
     };
-
     var formatObject = function formatObject(obj, depthLevel) {
       if (maxObjectDepth === depthLevel) return '-pruned-';
       var formatted = {};
       forEachEnumerableOwnProperty(obj, function (key) {
-        formatted[key] = format(obj[key], depthLevel + 1);
+        var value = obj[key];
+        if (whitelist.length === 0 || optimizedWhitelist[key]) {
+          formatted[key] = format(value, depthLevel + 1);
+        } else {
+          // Our log consumer does not mixed objects in arrays,
+          // i.e. cannot simply use '-redacted-' here.
+          if (Array.isArray(value)) {
+            formatted[key] = ['-redacted-'];
+          } else if (value && _typeof(value) === 'object') {
+            formatted[key] = {
+              redacted: true
+            };
+          } else {
+            formatted[key] = '-redacted-';
+          }
+        }
       });
       return formatted;
     };
-
     var formatError = function formatError(error) {
       return {
         message: error.message,
         stack: error.stack
       };
     };
-
     var format = function format(obj) {
       var depthLevel = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : 0;
       if (primitives.indexOf(_typeof(obj)) !== -1) return obj;else if (typeof obj === 'function') return '<Function>';else if (obj === null) return null;else if (obj instanceof Error) return formatError(obj);else if (Array.isArray(obj)) return formatArray(obj, depthLevel);else return formatObject(obj, depthLevel);
     };
-
     var log = function log(level) {
       return function () {
         if (isLiveLoggingEnabled()) {
           var writer = windowConsole[level] || windowConsole['log'];
           writer.apply(writer, arguments);
         }
-
         var attributes = Array.prototype.slice.call(arguments).map(function (arg) {
           return format(arg, 0);
         }).filter(function (attribute) {
@@ -224,7 +216,6 @@
           attributes: attributes,
           timestamp: currentIsoDate()
         });
-
         if (level === 'error') {
           params = merge(params, {
             breadcrumbs: breadcrumbs.list
@@ -232,40 +223,32 @@
         } else {
           breadcrumbs.add(params);
         }
-
         add(params);
       };
     };
-
     var findTopLevelError = function findTopLevelError(args) {
       return args.filter(function (arg) {
         return arg instanceof Error;
       })[0];
     };
-
     this.debug = log('debug');
     this.log = log('info');
     this.info = log('info');
     this.warn = log('warn');
-
     this.error = function () {
       var args = Array.prototype.slice.call(arguments);
       var maybeError = findTopLevelError(args);
-
       if (maybeError && maybeError._acked) {
         return;
       }
-
       if (typeof args[0] === 'string' && !maybeError) args[0] = new Error(args[0]);
       return log('error').apply(null, args);
     };
-
     this.withTags = function (newTags) {
       return new Logger(merge(_arguments[0], {
         tags: merge(tags, newTags)
       }));
     };
-
     this.enableLiveLogs = function () {
       return localStorage[liveLogsKey] = '1';
     };
@@ -276,37 +259,32 @@
       return obj[k];
     });
   };
-
   function Publisher() {
     var _ref = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {},
-        _ref$publishInterval = _ref.publishInterval,
-        publishInterval = _ref$publishInterval === void 0 ? 3000 : _ref$publishInterval,
-        _ref$maximumBatchSize = _ref.maximumBatchSize,
-        maximumBatchSize = _ref$maximumBatchSize === void 0 ? 50 : _ref$maximumBatchSize,
-        _ref$maximumBufferSiz = _ref.maximumBufferSize,
-        maximumBufferSize = _ref$maximumBufferSiz === void 0 ? 1000 : _ref$maximumBufferSiz,
-        _ref$maximumConsecuti = _ref.maximumConsecutiveRetries,
-        maximumConsecutiveRetries = _ref$maximumConsecuti === void 0 ? 10 : _ref$maximumConsecuti,
-        _ref$transports = _ref.transports,
-        transports = _ref$transports === void 0 ? [] : _ref$transports;
-
+      _ref$publishInterval = _ref.publishInterval,
+      publishInterval = _ref$publishInterval === void 0 ? 3000 : _ref$publishInterval,
+      _ref$maximumBatchSize = _ref.maximumBatchSize,
+      maximumBatchSize = _ref$maximumBatchSize === void 0 ? 50 : _ref$maximumBatchSize,
+      _ref$maximumBufferSiz = _ref.maximumBufferSize,
+      maximumBufferSize = _ref$maximumBufferSiz === void 0 ? 1000 : _ref$maximumBufferSiz,
+      _ref$maximumConsecuti = _ref.maximumConsecutiveRetries,
+      maximumConsecutiveRetries = _ref$maximumConsecuti === void 0 ? 10 : _ref$maximumConsecuti,
+      _ref$transports = _ref.transports,
+      transports = _ref$transports === void 0 ? [] : _ref$transports;
     var addTransport = function addTransport(transport) {
       var _ref2 = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {},
-          position = _ref2.position;
-
+        position = _ref2.position;
       // In normal languages we could just do `position || transports.length`. In
       // javascript however 0 is treated as false which sets the position to
       // transports.length.
       if (position === undefined) position = transports.length;
       transports.splice(position, 0, transport);
     };
-
     var buckets = {};
     var retries = {};
-
     var send = function send(_ref3) {
       var transports = _ref3.transports,
-          payload = _ref3.payload;
+        payload = _ref3.payload;
       if (transports.length === 0) return Promise.reject();
       return transports[0].process({
         payload: payload
@@ -317,19 +295,16 @@
         });
       });
     };
-
     var isEmptyPayload = function isEmptyPayload(payload) {
       return Object.keys(payload).length === 0 || objectValues(payload).every(function (items) {
         return items.length === 0;
       });
     };
-
     var flush = function flush() {
       var payload = {};
       Object.keys(buckets).forEach(function (key) {
         payload[key] = buckets[key].splice(0, maximumBatchSize);
       });
-
       if (!isEmptyPayload(payload)) {
         return send({
           transports: transports,
@@ -343,7 +318,6 @@
         })["catch"](function () {
           Object.keys(payload).forEach(function (key) {
             retries[key]++;
-
             if (retries[key] < maximumConsecutiveRetries) {
               buckets[key] = payload[key].concat(buckets[key]);
             } else {
@@ -357,11 +331,9 @@
         return Promise.resolve();
       }
     };
-
     var started = false;
     var timer = null;
     var flushInProgress = false;
-
     var start = function start() {
       if (started) throw new Error('Publisher is already started');
       started = true;
@@ -377,25 +349,20 @@
       }, publishInterval);
       window.addEventListener('unload', flush);
     };
-
     var stop = function stop() {
       started = false;
       clearInterval(timer);
     };
-
     var addToBucket = function addToBucket(bucketKey, item) {
       if (!buckets[bucketKey]) {
         if (!retries[bucketKey]) {
           retries[bucketKey] = 0;
         }
-
         buckets[bucketKey] = [];
       }
-
       buckets[bucketKey].push(item);
       buckets[bucketKey].splice(maximumBufferSize);
     };
-
     return {
       start: start,
       stop: stop,
@@ -409,13 +376,11 @@
 
   function StatsRecorder(_ref) {
     var publisher = _ref.publisher,
-        _ref$globalTags = _ref.globalTags,
-        globalTags = _ref$globalTags === void 0 ? [] : _ref$globalTags;
-
+      _ref$globalTags = _ref.globalTags,
+      globalTags = _ref$globalTags === void 0 ? [] : _ref$globalTags;
     var add = function add(item) {
       return publisher.addToBucket('stats', item);
     };
-
     var buildStat = function buildStat(stat, metric, value, tags) {
       if (!tags) tags = [];
       return {
@@ -423,41 +388,32 @@
         params: [metric, value, globalTags.concat(tags)]
       };
     };
-
     this.increment = function (metric, value, tags) {
       if (isNaN(parseInt(value))) {
         tags = value;
         value = 1;
       }
-
       add(buildStat('increment', metric, value, tags));
     };
-
     this.decrement = function (metric, value, tags) {
       if (isNaN(parseInt(value))) {
         tags = value;
         value = 1;
       }
-
       add(buildStat('decrement', metric, value, tags));
     };
-
     this.gauge = function (metric, value, tags) {
       add(buildStat('gauge', metric, value, tags));
     };
-
     this.histogram = function (metric, value, tags) {
       add(buildStat('histogram', metric, value, tags));
     };
-
     this.timing = function (metric, value, tags) {
       add(buildStat('timing', metric, value, tags));
     };
-
     this.set = function (metric, value, tags) {
       add(buildStat('set', metric, value, tags));
     };
-
     this.withTags = function (tags) {
       return new StatsRecorder({
         publisher: publisher,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client-logger",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "",
   "module": "dist/client-logger.esm.js",
   "browser": "dist/client-logger.umd.js",

--- a/test/LoggerTest.js
+++ b/test/LoggerTest.js
@@ -103,6 +103,35 @@ describe('Logger', () => {
         });
       });
 
+      context('when whitelist is passed', () => {
+        loggerOpts.is(() => ({
+          whitelist: ['some_object', 'baz']
+        }));
+
+        it('redacts various types of fields', () => {
+          const message = 'a message';
+
+          logger[level](message, {
+            some_object: {foo: 'foo', bar: ['bar'], baz: 'baz'},
+            other_object: {baz: 'baz'}
+          });
+
+          // redacts arrays as ['-redacted-'],
+          // objects as {redacted: true},
+          // everything else as '-redacted-'
+          expectLog({
+            level,
+            attributes: [
+              message,
+              {
+                some_object: {foo: '-redacted-', bar: ['-redacted-'], baz: 'baz'},
+                other_object: {redacted: true}
+              }
+            ]
+          });
+        });
+      });
+
       it('extracts error information from error object', () => {
         const error = new Error('oh snap');
 


### PR DESCRIPTION
BROW-1135

Allow whitelist to be passed to logger. If a whitelist object is
passed, it will check for the object keys in the whitelist. If
whitelist[key] does not exist or is false, the field value is replaced
with `-redacted-`, `['-redacted-']` or `{redacted: true}`, depending
on the value type.