### PR TITLE
Fix array in nested whitelist

### DIFF
--- a/dist/client-logger.esm.js
+++ b/dist/client-logger.esm.js
@@ -208,6 +208,7 @@ function Logger(_ref) {
     return windowConsole && (liveLogsEnabled || localStorage[liveLogsKey] === '1');
   };
   var formatArray = function formatArray(arr, depthLevel) {
+    var whiteListPath = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : [];
     if (maxObjectDepth === depthLevel) return ['-pruned-'];
     var formattedArray = [];
     for (var i = 0; i < arr.length; i++) {
@@ -227,7 +228,7 @@ function Logger(_ref) {
         }
         break;
       }
-      formattedArray.push(format(arr[i], depthLevel + 1));
+      formattedArray.push(format(arr[i], depthLevel + 1, whiteListPath));
     }
     return formattedArray;
   };
@@ -286,7 +287,7 @@ function Logger(_ref) {
   var format = function format(obj) {
     var depthLevel = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : 0;
     var whiteListPath = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : [];
-    if (primitives.indexOf(_typeof(obj)) !== -1) return obj;else if (typeof obj === 'function') return '<Function>';else if (obj === null) return null;else if (obj instanceof Error) return formatError(obj);else if (Array.isArray(obj)) return formatArray(obj, depthLevel);else return formatObject(obj, depthLevel, whiteListPath);
+    if (primitives.indexOf(_typeof(obj)) !== -1) return obj;else if (typeof obj === 'function') return '<Function>';else if (obj === null) return null;else if (obj instanceof Error) return formatError(obj);else if (Array.isArray(obj)) return formatArray(obj, depthLevel, whiteListPath);else return formatObject(obj, depthLevel, whiteListPath);
   };
   var log = function log(level) {
     return function () {

--- a/dist/client-logger.umd.js
+++ b/dist/client-logger.umd.js
@@ -214,6 +214,7 @@
       return windowConsole && (liveLogsEnabled || localStorage[liveLogsKey] === '1');
     };
     var formatArray = function formatArray(arr, depthLevel) {
+      var whiteListPath = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : [];
       if (maxObjectDepth === depthLevel) return ['-pruned-'];
       var formattedArray = [];
       for (var i = 0; i < arr.length; i++) {
@@ -233,7 +234,7 @@
           }
           break;
         }
-        formattedArray.push(format(arr[i], depthLevel + 1));
+        formattedArray.push(format(arr[i], depthLevel + 1, whiteListPath));
       }
       return formattedArray;
     };
@@ -292,7 +293,7 @@
     var format = function format(obj) {
       var depthLevel = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : 0;
       var whiteListPath = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : [];
-      if (primitives.indexOf(_typeof(obj)) !== -1) return obj;else if (typeof obj === 'function') return '<Function>';else if (obj === null) return null;else if (obj instanceof Error) return formatError(obj);else if (Array.isArray(obj)) return formatArray(obj, depthLevel);else return formatObject(obj, depthLevel, whiteListPath);
+      if (primitives.indexOf(_typeof(obj)) !== -1) return obj;else if (typeof obj === 'function') return '<Function>';else if (obj === null) return null;else if (obj instanceof Error) return formatError(obj);else if (Array.isArray(obj)) return formatArray(obj, depthLevel, whiteListPath);else return formatObject(obj, depthLevel, whiteListPath);
     };
     var log = function log(level) {
       return function () {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client-logger",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "description": "",
   "module": "dist/client-logger.esm.js",
   "browser": "dist/client-logger.umd.js",

--- a/src/Logger.js
+++ b/src/Logger.js
@@ -47,7 +47,7 @@ export default function Logger({
   const isLiveLoggingEnabled = () =>
     windowConsole && (liveLogsEnabled || localStorage[liveLogsKey] === '1');
 
-  const formatArray = (arr, depthLevel) => {
+  const formatArray = (arr, depthLevel, whiteListPath = []) => {
     if (maxObjectDepth === depthLevel) return ['-pruned-'];
 
     const formattedArray = [];
@@ -68,7 +68,7 @@ export default function Logger({
         break;
       }
 
-      formattedArray.push(format(arr[i], depthLevel + 1));
+      formattedArray.push(format(arr[i], depthLevel + 1, whiteListPath));
     }
 
     return formattedArray;
@@ -123,7 +123,7 @@ export default function Logger({
     else if (typeof obj === 'function') return '<Function>';
     else if (obj === null) return null;
     else if (obj instanceof Error) return formatError(obj);
-    else if (Array.isArray(obj)) return formatArray(obj, depthLevel);
+    else if (Array.isArray(obj)) return formatArray(obj, depthLevel, whiteListPath);
     else return formatObject(obj, depthLevel, whiteListPath);
   };
 

--- a/test/LoggerTest.js
+++ b/test/LoggerTest.js
@@ -136,6 +136,33 @@ describe('Logger', () => {
             ]
           });
         });
+
+        it('redacts array with various types of fields', () => {
+          const message = 'a message';
+
+          logger[level](message, [
+            {
+              allowed_value: 'allowed_value',
+              some_not_allowed_value: 'some_not_allowed_value',
+              some_object: {foo: 'foo', bar: ['bar'], baz: 'baz'},
+              other_object: {baz: 'baz'}
+            }
+          ]);
+          expectLog({
+            level,
+            attributes: [
+              message,
+              [
+                {
+                  allowed_value: 'allowed_value',
+                  other_object: {baz: '-redacted-'},
+                  some_not_allowed_value: '-redacted-',
+                  some_object: {bar: ['-redacted-'], baz: '-redacted-', foo: 'foo'}
+                }
+              ]
+            ]
+          });
+        });
       });
 
       it('extracts error information from error object', () => {


### PR DESCRIPTION
Previously added logic for nested whitelist had an error of
 not passing `whiteListPath` for proper construction
 of the filtering path for nested objects.

This commit fixes that.

BROW-1179